### PR TITLE
평균 시청 지속  시간, 구독자 증가 기여Top  영상 엔드 포인트 구현

### DIFF
--- a/back_end/src/main/java/com/cm/astb/AscenTubeApplication.java
+++ b/back_end/src/main/java/com/cm/astb/AscenTubeApplication.java
@@ -2,10 +2,9 @@ package com.cm.astb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
+//@EnableScheduling
 public class AscenTubeApplication {
 
 	public static void main(String[] args) {

--- a/back_end/src/main/java/com/cm/astb/controller/ChannelController.java
+++ b/back_end/src/main/java/com/cm/astb/controller/ChannelController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.cm.astb.dto.TopAverageWatchTimeVideoDto;
+import com.cm.astb.dto.TopSubscriberContributingVideoDto;
 import com.cm.astb.dto.VideoPerformanceDto;
 import com.cm.astb.security.CustomUserDetails;
 import com.cm.astb.service.ChannelService;
@@ -34,8 +36,7 @@ public class ChannelController {
 		this.videoAnalysisService = videoAnalysisService;
 	}
 
-	@GetMapping("/channel-info")
-	public ResponseEntity<?> getChannelInfo(@RequestParam("channelId") String channelId) {
+	public ResponseEntity<?> getChannelInfo(@RequestParam String channelId) {
 		try {
 
 			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -100,7 +101,6 @@ public class ChannelController {
 	
 	/**
      * 특정 채널의 최신 업로드 영상 성과 리스트를 반환하는 엔드포인트.
-     * 예시: GET /api/channels/{channelId}/latest-video-performance
      *
      * @param channelId 유튜브 채널 ID
      * @return 최신 영상 성과 정보 리스트
@@ -114,6 +114,42 @@ public class ChannelController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(performanceList);
+    }
+    
+    /**
+     * 특정 채널에서 구독자 증가 기여가 높은 영상 리스트를 반환하는 엔드포인트.
+     *
+     * @param channelId 유튜브 채널 ID
+     * @param limit     가져올 영상의 최대 개수 (기본값: 5)
+     * @return 구독자 증가 기여도 높은 영상 리스트
+     */
+    @GetMapping("/my-channel/top-sub-contribution")
+    public ResponseEntity<List<TopSubscriberContributingVideoDto>> getTopSubscriberVideos(
+            @RequestParam String channelId,
+            @RequestParam(defaultValue = "5") int limit) {
+        List<TopSubscriberContributingVideoDto> topVideos = videoAnalysisService.getTopSubscriberContributingVideos(channelId, limit);
+        if (topVideos.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(topVideos);
+    }
+    
+    /**
+     * 특정 채널에서 평균 시청 지속 시간이 높은 영상 리스트를 반환하는 엔드포인트.
+     *
+     * @param channelId 유튜브 채널 ID
+     * @param limit     가져올 영상의 최대 개수 (기본값: 5)
+     * @return 평균 시청 지속 시간 높은 영상 리스트
+     */
+    @GetMapping("/my-channel/top-avg-watch-time")
+    public ResponseEntity<List<TopAverageWatchTimeVideoDto>> getTopAverageWatchTimeVideos(
+            @RequestParam String channelId,
+            @RequestParam(defaultValue = "5") int limit) {
+        List<TopAverageWatchTimeVideoDto> topVideos = videoAnalysisService.getTopAverageWatchTimeVideos(channelId, limit);
+        if (topVideos.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(topVideos);
     }
 }
 

--- a/back_end/src/main/java/com/cm/astb/dto/TopAverageWatchTimeVideoDto.java
+++ b/back_end/src/main/java/com/cm/astb/dto/TopAverageWatchTimeVideoDto.java
@@ -1,0 +1,18 @@
+package com.cm.astb.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TopAverageWatchTimeVideoDto {
+    private String videoKey;
+    private String videoTitle;
+    private String thumbnailUrl;
+    private Integer avgWatchTime;
+    private Long viewCount;
+    private LocalDateTime uploadedAt;
+    private Integer videoPlaytime;
+}

--- a/back_end/src/main/java/com/cm/astb/service/VideoAnalysisService.java
+++ b/back_end/src/main/java/com/cm/astb/service/VideoAnalysisService.java
@@ -2,6 +2,7 @@ package com.cm.astb.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -11,6 +12,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.cm.astb.dto.TopAverageWatchTimeVideoDto;
+import com.cm.astb.dto.TopSubscriberContributingVideoDto;
 import com.cm.astb.dto.VideoPerformanceDto;
 import com.cm.astb.entity.VideoStat;
 import com.cm.astb.entity.YouTubeVideo;
@@ -88,5 +91,120 @@ public class VideoAnalysisService {
              logger.warn("No VideoPerformanceDto objects were created after filtering. Check DataCollectorService for stat saving.");
         }
         return performanceList;
+    }
+	
+	/**
+     * 특정 채널에서 구독자 증가 기여가 높은 영상들을 조회합니다.
+     * DB 쿼리 단계에서 정렬 및 제한을 적용하여 효율성을 높입니다.
+     *
+     * @param channelId 조회할 유튜브 채널 ID
+     * @param limit     가져올 영상의 최대 개수
+     * @return 구독자 증가 기여도 높은 영상 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<TopSubscriberContributingVideoDto> getTopSubscriberContributingVideos(String channelId, int limit) {
+        logger.info("Attempting to get {} top subscriber contributing videos for channelId: {}", limit, channelId);
+
+        List<YouTubeVideo> videos = youTubeVideoRepository.findByChannelId(channelId);
+        logger.info("Found {} YouTube videos for channelId: {}. Now filtering by VideoStat presence and sorting.", videos.size(), channelId);
+        if (videos.isEmpty()) {
+            logger.warn("No YouTube videos found for channelId: {}. Returning empty list.", channelId);
+            return List.of();
+        }
+
+        // 2. 통계 데이터를 가져올 기준 날짜를 설정합니다.
+        LocalDateTime latestStatsDate = LocalDate.now().minusDays(1).atStartOfDay();
+        logger.info("Attempting to retrieve VideoStat data for statsDate: {}", latestStatsDate);
+
+        // 3. 각 비디오에 대해 최신 통계를 찾아 DTO로 매핑하고, 필터링, 정렬, 제한을 적용합니다.
+        List<TopSubscriberContributingVideoDto> topVideos = videos.stream()
+                .map(video -> {
+                    Optional<VideoStat> latestStatOpt = videoStatRepository.findById_VideoIdAndId_StatsDate(video.getVideoId().intValue(), latestStatsDate);
+                    
+                    if (latestStatOpt.isPresent()) {
+                         VideoStat stat = latestStatOpt.get();
+                         logger.debug("Found VideoStat for top contributing video: videoKey={}, subscriberGained={}, viewCount={}",
+                                video.getVideoKey(), stat.getSubscriberGained(), stat.getViewCount());
+                         return TopSubscriberContributingVideoDto.builder()
+                                .videoKey(video.getVideoKey())
+                                .videoTitle(video.getVideoTitle())
+                                .thumbnailUrl(video.getThumbnailUrl())
+                                .subscriberGained(stat.getSubscriberGained())
+                                .viewCount(stat.getViewCount())
+                                .uploadedAt(video.getUploadedAt())
+                                .build();
+                    } else {
+                        logger.warn("No VideoStat found for videoKey: {}, videoId: {} on statsDate: {}. Skipping this video for top contribution analysis.",
+                                video.getVideoKey(), video.getVideoId(), latestStatsDate);
+                        return null; // 통계 데이터가 없으면 null 반환
+                    }
+                })
+                .filter(java.util.Objects::nonNull) // null 값 (VideoStat 없는 비디오) 제거
+                .sorted(Comparator.comparing(TopSubscriberContributingVideoDto::getSubscriberGained, Comparator.nullsLast(Comparator.reverseOrder())))
+                .limit(limit)
+                .collect(Collectors.toList());
+
+        logger.info("Finished collecting top subscriber contributing videos. Total DTOs created: {}", topVideos.size());
+        if (topVideos.isEmpty()) {
+             logger.warn("No TopSubscriberContributingVideoDto objects were created after filtering. Please ensure DataCollectorService has successfully saved VideoStat for channel {} on {}.", channelId, latestStatsDate);
+        }
+        return topVideos;
+    }
+    
+    /**
+     * 특정 채널에서 평균 시청 지속 시간이 높은 영상들을 조회합니다.
+     * 모든 비디오 메타데이터를 가져온 후, 최신 통계가 있는 영상들 중 평균 시청 지속 시간으로 정렬하여 반환합니다.
+     *
+     * @param channelId 조회할 유튜브 채널 ID
+     * @param limit     가져올 영상의 최대 개수
+     * @return 평균 시청 지속 시간 높은 영상 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<TopAverageWatchTimeVideoDto> getTopAverageWatchTimeVideos(String channelId, int limit) {
+        logger.info("Attempting to get {} top average watch time videos for channelId: {}", limit, channelId);
+
+        List<YouTubeVideo> videos = youTubeVideoRepository.findByChannelId(channelId);
+        logger.info("Found {} YouTube videos for channelId: {}. Now filtering by VideoStat presence and sorting.", videos.size(), channelId);
+        if (videos.isEmpty()) {
+            logger.warn("No YouTube videos found for channelId: {}. Returning empty list.", channelId);
+            return List.of();
+        }
+
+        LocalDateTime latestStatsDate = LocalDate.now().minusDays(1).atStartOfDay();
+        logger.info("Attempting to retrieve VideoStat data for statsDate: {}", latestStatsDate);
+
+        List<TopAverageWatchTimeVideoDto> topVideos = videos.stream()
+                .map(video -> {
+                    Optional<VideoStat> latestStatOpt = videoStatRepository.findById_VideoIdAndId_StatsDate(video.getVideoId().intValue(), latestStatsDate);
+
+                    if (latestStatOpt.isPresent()) {
+                         VideoStat stat = latestStatOpt.get();
+                         logger.debug("Found VideoStat for top average watch time video: videoKey={}, avgWatchTime={}, viewCount={}",
+                                video.getVideoKey(), stat.getAvgWatchTime(), stat.getViewCount());
+                         return TopAverageWatchTimeVideoDto.builder()
+                                .videoKey(video.getVideoKey())
+                                .videoTitle(video.getVideoTitle())
+                                .thumbnailUrl(video.getThumbnailUrl())
+                                .avgWatchTime(stat.getAvgWatchTime())
+                                .viewCount(stat.getViewCount())
+                                .uploadedAt(video.getUploadedAt())
+                                .videoPlaytime(video.getVideoPlaytime())
+                                .build();
+                    } else {
+                        logger.warn("No VideoStat found for videoKey: {}, videoId: {} on statsDate: {}. Skipping this video for top average watch time analysis.",
+                                video.getVideoKey(), video.getVideoId(), latestStatsDate);
+                        return null;
+                    }
+                })
+                .filter(java.util.Objects::nonNull) // null 값 (VideoStat 없는 비디오) 제거
+                .sorted(Comparator.comparing(TopAverageWatchTimeVideoDto::getAvgWatchTime, Comparator.nullsLast(Comparator.reverseOrder())))
+                .limit(limit)
+                .collect(Collectors.toList());
+
+        logger.info("Finished collecting top average watch time videos. Total DTOs created: {}", topVideos.size());
+        if (topVideos.isEmpty()) {
+             logger.warn("No TopAverageWatchTimeVideoDto objects were created after filtering. Please ensure DataCollectorService has successfully saved VideoStat for channel {} on {}.", channelId, latestStatsDate);
+        }
+        return topVideos;
     }
 }


### PR DESCRIPTION
메인 대시보드 내 콘텐츠 성과 섹션 내 '평균 시청 지속 시간 TOP 영상', '구독자 증가 기역 TOP 영상' 데이터 반환 엔드 포인트 구현.